### PR TITLE
fix: MIGRATION_11_12 duplicate column crash (Erro ao carregar grupos)

### DIFF
--- a/app/src/main/java/activity/amigosecreto/db/room/AppDatabase.kt
+++ b/app/src/main/java/activity/amigosecreto/db/room/AppDatabase.kt
@@ -150,26 +150,46 @@ abstract class AppDatabase : RoomDatabase() {
          *
          * All new columns have default values so existing rows are preserved intact.
          *
+         * Uses addColumnIfMissing() to guard each ALTER TABLE — some devices had these
+         * columns already present (added by a previous Room instance before the migration
+         * ran), causing "duplicate column name" errors and crash on startup.
+         *
          * Note: sorteio and sorteio_par already exist — they were created in MIGRATION_10_11.
          * This migration only alters grupo and participante via ALTER TABLE ADD COLUMN.
          */
         val MIGRATION_11_12 = object : Migration(11, 12) {
+            private fun columnExists(db: SupportSQLiteDatabase, table: String, column: String): Boolean {
+                db.query("PRAGMA table_info(`$table`)").use { cursor ->
+                    val nameIdx = cursor.getColumnIndex("name")
+                    while (cursor.moveToNext()) {
+                        if (cursor.getString(nameIdx) == column) return true
+                    }
+                }
+                return false
+            }
+
+            private fun addColumnIfMissing(db: SupportSQLiteDatabase, table: String, column: String, definition: String) {
+                if (!columnExists(db, table, column)) {
+                    db.execSQL("ALTER TABLE `$table` ADD COLUMN `$column` $definition")
+                }
+            }
+
             override fun migrate(db: SupportSQLiteDatabase) {
                 // --- grupo: new configuration columns ---
-                db.execSQL("ALTER TABLE grupo ADD COLUMN `descricao` TEXT")
-                db.execSQL("ALTER TABLE grupo ADD COLUMN `data_evento` TEXT")
-                db.execSQL("ALTER TABLE grupo ADD COLUMN `local_evento` TEXT")
-                db.execSQL("ALTER TABLE grupo ADD COLUMN `data_limite_sorteio` TEXT")
-                db.execSQL("ALTER TABLE grupo ADD COLUMN `valor_minimo` REAL NOT NULL DEFAULT 0.0")
-                db.execSQL("ALTER TABLE grupo ADD COLUMN `valor_maximo` REAL NOT NULL DEFAULT 0.0")
-                db.execSQL("ALTER TABLE grupo ADD COLUMN `regras` TEXT")
-                db.execSQL("ALTER TABLE grupo ADD COLUMN `permitir_ver_desejos` INTEGER NOT NULL DEFAULT 1")
-                db.execSQL("ALTER TABLE grupo ADD COLUMN `exigir_confirmacao_compra` INTEGER NOT NULL DEFAULT 0")
+                addColumnIfMissing(db, "grupo", "descricao", "TEXT")
+                addColumnIfMissing(db, "grupo", "data_evento", "TEXT")
+                addColumnIfMissing(db, "grupo", "local_evento", "TEXT")
+                addColumnIfMissing(db, "grupo", "data_limite_sorteio", "TEXT")
+                addColumnIfMissing(db, "grupo", "valor_minimo", "REAL NOT NULL DEFAULT 0.0")
+                addColumnIfMissing(db, "grupo", "valor_maximo", "REAL NOT NULL DEFAULT 0.0")
+                addColumnIfMissing(db, "grupo", "regras", "TEXT")
+                addColumnIfMissing(db, "grupo", "permitir_ver_desejos", "INTEGER NOT NULL DEFAULT 1")
+                addColumnIfMissing(db, "grupo", "exigir_confirmacao_compra", "INTEGER NOT NULL DEFAULT 0")
 
                 // --- participante: new tracking columns ---
-                db.execSQL("ALTER TABLE participante ADD COLUMN `confirmou_presente` INTEGER NOT NULL DEFAULT 0")
-                db.execSQL("ALTER TABLE participante ADD COLUMN `foi_notificado` INTEGER NOT NULL DEFAULT 0")
-                db.execSQL("ALTER TABLE participante ADD COLUMN `observacoes` TEXT")
+                addColumnIfMissing(db, "participante", "confirmou_presente", "INTEGER NOT NULL DEFAULT 0")
+                addColumnIfMissing(db, "participante", "foi_notificado", "INTEGER NOT NULL DEFAULT 0")
+                addColumnIfMissing(db, "participante", "observacoes", "TEXT")
             }
         }
 


### PR DESCRIPTION
## Problema

Crash na tela inicial após atualização do app: **\"Erro ao carregar grupos\"**.

**Causa raiz:** `MIGRATION_11_12` executava `ALTER TABLE ADD COLUMN` diretamente. Em dispositivos que já possuíam as colunas v12 pré-populadas (por uma instância Room anterior antes da migração rodar), o SQLite lançava:

```
E SQLiteLog: (1) duplicate column name: descricao in "ALTER TABLE grupo ADD COLUMN descricao TEXT"
```

Isso causava rollback da transação de migração → Room lançava `IllegalStateException` → crash na inicialização do banco.

## Solução

Reescreve `MIGRATION_11_12` para usar `addColumnIfMissing()` — verifica via `PRAGMA table_info` se cada coluna já existe antes de tentar adicioná-la. A migração passa a ser idempotente.

```kotlin
private fun addColumnIfMissing(db: SupportSQLiteDatabase, table: String, column: String, definition: String) {
    if (!columnExists(db, table, column)) {
        db.execSQL("ALTER TABLE `$table` ADD COLUMN `$column` $definition")
    }
}
```

## Impacto

- Todos os usuários com banco em versão 11 que já tinham colunas v12 pré-existentes agora migram sem crash
- Usuários sem as colunas continuam recebendo-as normalmente
- Sem alteração de dados — apenas proteção contra coluna duplicada

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — BUILD SUCCESSFUL (todos os testes passam)
- [x] `./gradlew :app:lintRelease` — sem erros novos
- [x] APK de debug instalado e lançado no device físico (RQ8M605Z1NP) sem crash
- [x] Logcat sem `SQLiteLog`, `duplicate column name`, `IllegalState` ou `FATAL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)