### PR TITLE
fix(ci): corrige erro whatsnew idioma lv no upload Play Store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: internal
           status: completed
+          whatsNewDirectory: distribution/whatsnew
 
       - name: Cleanup keystore
         if: always()

--- a/distribution/whatsnew/whatsnew-lv
+++ b/distribution/whatsnew/whatsnew-lv
@@ -1,0 +1,4 @@
+Version 3.1 - Multilanguage support
+
+The app is now available in English and Spanish.
+The language is automatically selected based on your device settings.


### PR DESCRIPTION
## Problema

O CI (`CI Build & Internal Deploy`) falhou com:
```
One or more of the languages are not supported for translation: lv
```

A action `r0adkll/upload-google-play` tenta enviar notas de versão para todos os idiomas cadastrados no Play Console. O app tem `lv` (letão) cadastrado na loja, mas não havia arquivo `whatsnew-lv` na pasta.

## Correção

- Criado `distribution/whatsnew/whatsnew-lv` com conteúdo em inglês (fallback padrão)
- Adicionado `whatsNewDirectory: distribution/whatsnew` explícito no `ci.yml` (o `release.yml` já tinha)

## Teste

Após merge, o próximo push no master vai disparar o CI e confirmar que o upload para internal track passa sem erro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)