### PR TITLE
fix(privacy): remove permissão READ_CONTACTS — conformidade com nova política Google Play

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,6 @@ androidTestImplementation 'androidx.test:rules:1.6.1'
 - `INTERNET` — WhatsApp e Buscape
 - `ACCESS_NETWORK_STATE` — verificação de conectividade
 - `VIBRATE` — feedback háptico
-- `READ_CONTACTS` — importar participantes
 
 ---
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,9 +15,6 @@
     <!-- Device permissions -->
     <uses-permission android:name="android.permission.VIBRATE"/>
 
-    <!-- Contacts permission - optional, used to import participants from contacts -->
-    <uses-permission android:name="android.permission.READ_CONTACTS" />
-
     <!-- Notification permission (required on Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 

--- a/app/src/main/java/activity/amigosecreto/ParticipantesActivity.kt
+++ b/app/src/main/java/activity/amigosecreto/ParticipantesActivity.kt
@@ -1,12 +1,10 @@
 package activity.amigosecreto
 
-import android.Manifest
 import timber.log.Timber
 import android.content.Context
 import android.content.Intent
 import android.view.Menu
 import android.view.MenuItem
-import android.content.pm.PackageManager
 import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
@@ -24,7 +22,6 @@ import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
@@ -47,7 +44,6 @@ class ParticipantesActivity : AppCompatActivity() {
 
     private companion object {
         private const val TAG = "ParticipantesActivity"
-        const val PERMISSIONS_REQUEST_READ_CONTACTS = 100
         const val REQUEST_CONTACT_PICKER = 200
     }
 
@@ -423,11 +419,7 @@ class ParticipantesActivity : AppCompatActivity() {
         val btnPickContact = view.findViewById<View>(R.id.btn_pick_contact)
 
         btnPickContact.setOnClickListener {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CONTACTS) != PackageManager.PERMISSION_GRANTED) {
-                ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.READ_CONTACTS), PERMISSIONS_REQUEST_READ_CONTACTS)
-            } else {
-                abrirSeletorContatos()
-            }
+            abrirSeletorContatos()
         }
 
         val builder = AlertDialog.Builder(this)
@@ -656,14 +648,6 @@ class ParticipantesActivity : AppCompatActivity() {
         }
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == PERMISSIONS_REQUEST_READ_CONTACTS) {
-            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                abrirSeletorContatos()
-            }
-        }
-    }
 
     private fun confirmarLimparTudo() {
         AlertDialog.Builder(this)


### PR DESCRIPTION
## Contexto

O Google Play anunciou a nova **Contacts Permissions policy** (abril 2026, prazo de 30 dias). Apps que não precisam de acesso amplo aos contatos devem usar o **Android Contact Picker** em vez de `READ_CONTACTS`.

## Análise

O app já usava `ACTION_PICK` (Contact Picker) para importar participantes, mas pedia `READ_CONTACTS` desnecessariamente antes de abrir o picker. O picker concede permissão implícita apenas ao contato selecionado — sem necessidade de acesso amplo.

## Mudanças

- Remove `READ_CONTACTS` do `AndroidManifest.xml`
- Remove check de runtime permission em `exibirDialogAdd()`
- Remove `onRequestPermissionsResult()` (ficou vazio)
- Remove imports não utilizados (`Manifest`, `ActivityCompat`, `PackageManager`)
- Atualiza `CLAUDE.md` (lista de permissões)

## Impacto no usuário

**Nenhum impacto negativo.** O fluxo permanece idêntico:
1. Clica em "Importar contato"
2. Picker nativo abre (sem dialog de permissão)
3. Seleciona contato → dados preenchidos

**Melhoria:** o usuário não vê mais o dialog "Permitir acesso aos contatos" — o picker abre direto.

## Teste

- [x] `./gradlew :app:testDebugUnitTest` — todos os testes passam
- [ ] Testar manualmente: importar contato no dialog de adicionar participante

🤖 Generated with [Claude Code](https://claude.com/claude-code)