### PR TITLE
ci: uploads de artifact não-bloqueantes + retenção 3 dias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,14 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Upload AAB as build artifact
+        # Upload de artifact é auxiliar — erro de quota de storage não pode
+        # derrubar o job (conta atingiu a quota em 2026-06-11).
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: internal-aab
           path: app/build/outputs/bundle/release/app-release.aab
-          retention-days: 30
+          retention-days: 3
 
       - name: Publish to Google Play (internal track)
         uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1.1.3

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -41,13 +41,16 @@ jobs:
 
       - name: Upload unit test results
         if: always()
+        # Upload de artifact é auxiliar — erro de quota de storage não pode
+        # derrubar o job (conta atingiu a quota em 2026-06-11).
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: unit-test-results-pr-${{ github.event.pull_request.number }}
           path: |
             app/build/reports/tests/testDebugUnitTest/
             app/build/test-results/testDebugUnitTest/
-          retention-days: 14
+          retention-days: 3
 
       - name: Publish unit test results as PR check
         if: always()
@@ -66,11 +69,14 @@ jobs:
 
       - name: Upload lint results
         if: always()
+        # Upload de artifact é auxiliar — erro de quota de storage não pode
+        # derrubar o job (conta atingiu a quota em 2026-06-11).
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: lint-results-pr-${{ github.event.pull_request.number }}
           path: app/build/reports/lint-results-release.html
-          retention-days: 14
+          retention-days: 3
 
   # -----------------------------------------------------------------------
   # Job 2: Testes instrumentados Espresso (requer emulador Android)
@@ -116,13 +122,16 @@ jobs:
 
       - name: Upload instrumented test results
         if: always()
+        # Upload de artifact é auxiliar — erro de quota de storage não pode
+        # derrubar o job (conta atingiu a quota em 2026-06-11).
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: instrumented-test-results-pr-${{ github.event.pull_request.number }}
           path: |
             app/build/reports/androidTests/connected/
             app/build/outputs/androidTest-results/connected/
-          retention-days: 14
+          retention-days: 3
 
       - name: Publish instrumented test results as PR check
         if: always()
@@ -164,8 +173,11 @@ jobs:
         run: ./gradlew :app:assembleDebug
 
       - name: Upload debug APK
+        # Upload de artifact é auxiliar — erro de quota de storage não pode
+        # derrubar o job (conta atingiu a quota em 2026-06-11).
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: debug-apk-pr-${{ github.event.pull_request.number }}
           path: app/build/outputs/apk/debug/app-debug.apk
-          retention-days: 7
+          retention-days: 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,9 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Upload AAB as build artifact
+        # Upload de artifact é auxiliar — erro de quota de storage não pode
+        # derrubar o job (conta atingiu a quota em 2026-06-11).
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: release-aab
@@ -103,6 +106,9 @@ jobs:
           retention-days: 90
 
       - name: Upload mapping file
+        # Upload de artifact é auxiliar — erro de quota de storage não pode
+        # derrubar o job (conta atingiu a quota em 2026-06-11).
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: mapping


### PR DESCRIPTION
## Summary

A conta GitHub atingiu a quota de artifact storage (6GB vs 500MB do free) em 2026-06-11 — jobs com upload falhavam com testes verdes. Este repo era o maior acumulador: **1.174 artifacts / 1,6GB** (já deletados manualmente).

- `continue-on-error: true` nos 7 uploads (ci, pr-checks ×4, release ×2) — quota não derruba mais o CI nem aborta release antes do publish no Google Play
- Retenção 30/14/7 → **3 dias** em ci.yml e pr-checks.yml (relatórios de lint/teste descartáveis)
- release.yml **mantém 90 dias** (AAB + mapping.txt — poucos e valiosos)

## Test plan
- [ ] CI verde neste PR
- [ ] Próximo run de pr-checks deve subir artifacts com retenção 3d

🤖 Generated with [Claude Code](https://claude.com/claude-code)